### PR TITLE
Add Boards Manager JSON file

### DIFF
--- a/package_drazzy.com_index.json
+++ b/package_drazzy.com_index.json
@@ -1,0 +1,101 @@
+{
+  "packages": [
+    {
+      "name": "ATTinyCore",
+      "maintainer": "Spence Konde",
+      "websiteURL": "https://github.com/SpenceKonde/ATTinyCore",
+      "email": "",
+      "help": {
+        "online": ""
+      },
+      "platforms": [
+        {
+          "name": "ATTinyCore",
+          "architecture": "avr",
+          "version": "1.0.4",
+          "category": "Contributed",
+          "help": {
+            "online": ""
+          },
+          "url": "https://github.com/SpenceKonde/ATTinyCore/archive/v1.0.4.tar.gz",
+          "archiveFileName": "ATTinyCore-1.0.4.tar.gz",
+          "checksum": "SHA-256:c647ad9efebbb44ce50153c0598b8152b6df381d0a77333e3f75c9afddad33bf",
+          "size": "249576",
+          "boards": [
+            {"name": "ATtiny2313"},
+            {"name": "ATtiny4313"},
+            {"name": "ATtiny24"},
+            {"name": "ATtiny44"},
+            {"name": "ATtiny84"},
+            {"name": "ATtiny25"},
+            {"name": "ATtiny45"},
+            {"name": "ATtiny85"},
+            {"name": "ATtiny261"},
+            {"name": "ATtiny461"},
+            {"name": "ATtiny861"},
+            {"name": "ATtiny87"},
+            {"name": "ATtiny167"},
+            {"name": "ATtiny48"},
+            {"name": "ATtiny88"}
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avr-gcc",
+              "version": "4.8.1-arduino5"
+            },
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.0.1-arduino5"
+            }
+          ]
+        }
+      ],
+      "tools": []
+    },
+    {
+      "name": "arduino-tiny-841",
+      "maintainer": "Spence Konde",
+      "websiteURL": "https://github.com/SpenceKonde/arduino-tiny-841",
+      "email": "",
+      "help": {
+        "online": ""
+      },
+      "platforms": [
+        {
+          "name": "ATtiny Modern",
+          "architecture": "avr",
+          "version": "1.0.4",
+          "category": "Contributed",
+          "help": {
+            "online": ""
+          },
+          "url": "https://github.com/SpenceKonde/arduino-tiny-841/archive/v1.0.4.tar.gz",
+          "archiveFileName": "arduino-tiny-841-1.0.4.tar.gz",
+          "checksum": "SHA-256:1e100474ed43ff639dce3dd217d119e725d122f3975ce94edb6f124fe554db48",
+          "size": "116602",
+          "boards": [
+            {"name": "ATtiny441"},
+            {"name": "ATtiny841"},
+            {"name": "ATtiny1634"},
+            {"name": "ATtiny828"}
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avr-gcc",
+              "version": "4.8.1-arduino5"
+            },
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.0.1-arduino5"
+            }
+          ]
+        }
+      ],
+      "tools": []
+    }
+  ]
+}


### PR DESCRIPTION
Adds Boards Manager install support for ATTinyCore and arduino-tiny-841.
![clipboard01](https://cloud.githubusercontent.com/assets/8572152/9985772/68218e00-5fe7-11e5-97d2-915821760050.gif)
- Boards Manager install URL for testing: https://raw.githubusercontent.com/per1234/ReleaseScripts/add-JSON-file/package_drazzy.com_index.json
- **More info** links are to:
  - https://github.com/SpenceKonde/ATTinyCore
  - https://github.com/SpenceKonde/arduino-tiny-841
- Install tested with Arduino IDE 1.6.5r5 and 1.6.6 Hourly Build 2015/09/18 06:03
- Note: There is a bug(https://github.com/arduino/Arduino/issues/3795) in the hourly build that requires you to open Boards Manager twice before the entries for a newly added URL will appear.

Happy to make any changes, just let me know.
