### PR TITLE
Add ATTinyCore v1.1.1, ATtiny Modern deprecation notice

### DIFF
--- a/package_drazzy.com_index.json
+++ b/package_drazzy.com_index.json
@@ -240,7 +240,7 @@
       },
       "platforms": [
         {
-          "name": "ATtiny Modern",
+          "name": "ATtiny Modern(deprecated, use ATTinyCore instead)",
           "architecture": "avr",
           "version": "1.0.4",
           "category": "Contributed",
@@ -271,7 +271,7 @@
           ]
         },
         {
-          "name": "ATtiny Modern",
+          "name": "ATtiny Modern(deprecated, use ATTinyCore instead)",
           "architecture": "avr",
           "version": "1.0.5",
           "category": "Contributed",
@@ -302,7 +302,7 @@
           ]
         },
         {
-          "name": "ATtiny Modern",
+          "name": "ATtiny Modern(deprecated, use ATTinyCore instead)",
           "architecture": "avr",
           "version": "1.0.6",
           "category": "Contributed",
@@ -318,6 +318,34 @@
             {"name": "ATtiny841"},
             {"name": "ATtiny1634"},
             {"name": "ATtiny828"}
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avr-gcc",
+              "version": "4.8.1-arduino5"
+            },
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.0.1-arduino5"
+            }
+          ]
+        },
+        {
+          "name": "ATtiny Modern(deprecated, use ATTinyCore instead)",
+          "architecture": "avr",
+          "version": "1.0.7-deprecation-notice",
+          "category": "Contributed",
+          "help": {
+            "online": ""
+          },
+          "url": "https://github.com/SpenceKonde/arduino-tiny-841/archive/v1.0.6.tar.gz",
+          "archiveFileName": "arduino-tiny-841-1.0.6.tar.gz",
+          "checksum": "SHA-256:f705cd4c6cda59ebc45eb74c7df749191f2ac5451d83aa57efdf2d477c152e98",
+          "size": "121546",
+          "boards": [
+            {"name": "ATTENTION! ATtiny Modern has been merged with ATTinyCore. If you have ATtiny Modern installed please click the Remove button and install ATTinyCore."}
           ],
           "toolsDependencies": [
             {

--- a/package_drazzy.com_index.json
+++ b/package_drazzy.com_index.json
@@ -180,6 +180,52 @@
               "version": "6.0.1-arduino5"
             }
           ]
+        },
+        {
+          "name": "ATTinyCore",
+          "architecture": "avr",
+          "version": "1.1.1",
+          "category": "Contributed",
+          "help": {
+            "online": ""
+          },
+          "url": "https://github.com/SpenceKonde/ATTinyCore/archive/v1.1.1.3.tar.gz",
+          "archiveFileName": "ATTinyCore-1.1.1.3.tar.gz",
+          "checksum": "SHA-256:eafd5e2db5812764b6d6b8889c0cf4bfaa62dfefaf1cd139ba92898bd20bc85e",
+          "size": "173202",
+          "boards": [
+            {"name": "ATtiny441"},
+            {"name": "ATtiny841"},
+            {"name": "ATtiny1634"},
+            {"name": "ATtiny828"},
+            {"name": "ATtiny2313"},
+            {"name": "ATtiny4313"},
+            {"name": "ATtiny24"},
+            {"name": "ATtiny44"},
+            {"name": "ATtiny84"},
+            {"name": "ATtiny25"},
+            {"name": "ATtiny45"},
+            {"name": "ATtiny85"},
+            {"name": "ATtiny261"},
+            {"name": "ATtiny461"},
+            {"name": "ATtiny861"},
+            {"name": "ATtiny87"},
+            {"name": "ATtiny167"},
+            {"name": "ATtiny48"},
+            {"name": "ATtiny88"}
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avr-gcc",
+              "version": "4.8.1-arduino5"
+            },
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.0.1-arduino5"
+            }
+          ]
         }
       ],
       "tools": []


### PR DESCRIPTION
Boards Manager URL for testing: https://raw.githubusercontent.com/per1234/ReleaseScripts/add-111/package_drazzy.com_index.json
![clipboard01](https://cloud.githubusercontent.com/assets/8572152/15203519/723441f0-17b9-11e6-8917-2a527b1b7f44.gif)
