### PR TITLE
Boards Manager installation support for ATTinyCore 1.1.2

### DIFF
--- a/package_drazzy.com_index.json
+++ b/package_drazzy.com_index.json
@@ -171,6 +171,41 @@
             {"name": "ATtiny88"}
           ],
           "toolsDependencies": []
+        },
+        {
+          "name": "ATTinyCore",
+          "architecture": "avr",
+          "version": "1.1.2",
+          "category": "Contributed",
+          "help": {
+            "online": ""
+          },
+          "url": "https://github.com/SpenceKonde/ATTinyCore/archive/v1.1.2.tar.gz",
+          "archiveFileName": "ATTinyCore-1.1.2.tar.gz",
+          "checksum": "SHA-256:b5b03ba5c1544f159804b8067bbb61e27fc5eaa1ba0b5cdc7ac08fd2bdefcf18",
+          "size": "3951319",
+          "boards": [
+            {"name": "ATtiny441"},
+            {"name": "ATtiny841"},
+            {"name": "ATtiny1634"},
+            {"name": "ATtiny828"},
+            {"name": "ATtiny2313"},
+            {"name": "ATtiny4313"},
+            {"name": "ATtiny24"},
+            {"name": "ATtiny44"},
+            {"name": "ATtiny84"},
+            {"name": "ATtiny25"},
+            {"name": "ATtiny45"},
+            {"name": "ATtiny85"},
+            {"name": "ATtiny261"},
+            {"name": "ATtiny461"},
+            {"name": "ATtiny861"},
+            {"name": "ATtiny87"},
+            {"name": "ATtiny167"},
+            {"name": "ATtiny48"},
+            {"name": "ATtiny88"}
+          ],
+          "toolsDependencies": []
         }
       ],
       "tools": []


### PR DESCRIPTION
Temporary Boards Manager URL for testing:
https://raw.githubusercontent.com/per1234/ReleaseScripts/add-112/package_drazzy.com_index.json
