### PR TITLE
Add Boards Manager installation support for ATTinyCore 1.1.5

### DIFF
--- a/package_drazzy.com_index.json
+++ b/package_drazzy.com_index.json
@@ -276,6 +276,41 @@
             {"name": "ATtiny88"}
           ],
           "toolsDependencies": []
+        },
+        {
+          "name": "ATTinyCore",
+          "architecture": "avr",
+          "version": "1.1.5",
+          "category": "Contributed",
+          "help": {
+            "online": ""
+          },
+          "url": "https://github.com/SpenceKonde/ATTinyCore/archive/1.1.5.tar.gz",
+          "archiveFileName": "ATTinyCore-1.1.5.tar.gz",
+          "checksum": "SHA-256:ae4d9deb0dc00f3f673000782dc9ae62a432603f25364350fd1d18b37fcc12a5",
+          "size": "6402856",
+          "boards": [
+            {"name": "ATtiny441"},
+            {"name": "ATtiny841"},
+            {"name": "ATtiny1634"},
+            {"name": "ATtiny828"},
+            {"name": "ATtiny2313"},
+            {"name": "ATtiny4313"},
+            {"name": "ATtiny24"},
+            {"name": "ATtiny44"},
+            {"name": "ATtiny84"},
+            {"name": "ATtiny25"},
+            {"name": "ATtiny45"},
+            {"name": "ATtiny85"},
+            {"name": "ATtiny261"},
+            {"name": "ATtiny461"},
+            {"name": "ATtiny861"},
+            {"name": "ATtiny87"},
+            {"name": "ATtiny167"},
+            {"name": "ATtiny48"},
+            {"name": "ATtiny88"}
+          ],
+          "toolsDependencies": []
         }
       ],
       "tools": []


### PR DESCRIPTION
Boards Manager URL for testing: https://raw.githubusercontent.com/per1234/ReleaseScripts/add-115/package_drazzy.com_index.json