### PR TITLE
Add Boards Manager installation support for ATTinyCore 1.2.0

### DIFF
--- a/package_drazzy.com_index.json
+++ b/package_drazzy.com_index.json
@@ -311,6 +311,41 @@
             {"name": "ATtiny88"}
           ],
           "toolsDependencies": []
+        },
+        {
+          "name": "ATTinyCore",
+          "architecture": "avr",
+          "version": "1.2.0",
+          "category": "Contributed",
+          "help": {
+            "online": ""
+          },
+          "url": "https://github.com/SpenceKonde/ATTinyCore/archive/1.2.0.tar.gz",
+          "archiveFileName": "ATTinyCore-1.2.0.tar.gz",
+          "checksum": "SHA-256:6f68e52961c3b1706ac458792f047e9ca5cb37204d012f891cd49f5a81f3febe",
+          "size": "6429419",
+          "boards": [
+            {"name": "ATtiny441"},
+            {"name": "ATtiny841"},
+            {"name": "ATtiny1634"},
+            {"name": "ATtiny828"},
+            {"name": "ATtiny2313"},
+            {"name": "ATtiny4313"},
+            {"name": "ATtiny24"},
+            {"name": "ATtiny44"},
+            {"name": "ATtiny84"},
+            {"name": "ATtiny25"},
+            {"name": "ATtiny45"},
+            {"name": "ATtiny85"},
+            {"name": "ATtiny261"},
+            {"name": "ATtiny461"},
+            {"name": "ATtiny861"},
+            {"name": "ATtiny87"},
+            {"name": "ATtiny167"},
+            {"name": "ATtiny48"},
+            {"name": "ATtiny88"}
+          ],
+          "toolsDependencies": []
         }
       ],
       "tools": []


### PR DESCRIPTION
Boards Manager URL for testing:
https://raw.githubusercontent.com/per1234/ReleaseScripts/add-120/package_drazzy.com_index.json
