### PR TITLE
Add Boards Manager installation support for ATTinyCore 1.2.3

### DIFF
--- a/package_drazzy.com_index.json
+++ b/package_drazzy.com_index.json
@@ -417,6 +417,42 @@
             {"name": "ATtiny43"}
           ],
           "toolsDependencies": []
+        },
+        {
+          "name": "ATTinyCore",
+          "architecture": "avr",
+          "version": "1.2.3",
+          "category": "Contributed",
+          "help": {
+            "online": ""
+          },
+          "url": "https://github.com/SpenceKonde/ATTinyCore/archive/1.2.3.tar.gz",
+          "archiveFileName": "ATTinyCore-1.2.3.tar.gz",
+          "checksum": "SHA-256:0c08e01138002f8b060faf961c6cf8d5f907082fabb02fec55d56f12f7c82525",
+          "size": "7035195",
+          "boards": [
+            {"name": "ATtiny441"},
+            {"name": "ATtiny841"},
+            {"name": "ATtiny1634"},
+            {"name": "ATtiny828"},
+            {"name": "ATtiny2313"},
+            {"name": "ATtiny4313"},
+            {"name": "ATtiny24"},
+            {"name": "ATtiny44"},
+            {"name": "ATtiny84"},
+            {"name": "ATtiny25"},
+            {"name": "ATtiny45"},
+            {"name": "ATtiny85"},
+            {"name": "ATtiny261"},
+            {"name": "ATtiny461"},
+            {"name": "ATtiny861"},
+            {"name": "ATtiny87"},
+            {"name": "ATtiny167"},
+            {"name": "ATtiny48"},
+            {"name": "ATtiny88"},
+            {"name": "ATtiny43"}
+          ],
+          "toolsDependencies": []
         }
       ],
       "tools": []


### PR DESCRIPTION
Boards Manager URL for testing: https://raw.githubusercontent.com/per1234/ReleaseScripts/add-123/package_drazzy.com_index.json