### PR TITLE
Add Boards Manager installation support for megaTinyCore 1.0.1

### DIFF
--- a/package_drazzy.com_index.json
+++ b/package_drazzy.com_index.json
@@ -521,6 +521,26 @@
             {"name": "ATtiny3217/1617/1607/817/807"}
           ],
           "toolsDependencies": []
+        },
+        {
+          "name": "megaTinyCore",
+          "architecture": "megaavr",
+          "version": "1.0.1",
+          "category": "Contributed",
+          "help": {
+            "online": ""
+          },
+          "url": "https://github.com/SpenceKonde/megaTinyCore/archive/1.0.1.tar.gz",
+          "archiveFileName": "megaTinyCore-1.0.1.tar.gz",
+          "checksum": "SHA-256:a16cffad928e173ccb02f2af057a6449014b17a5b83e08133552f57e1e121a94",
+          "size": "8088593",
+          "boards": [
+            {"name": "ATtiny3216/1616/1606/816/806/416/406"},
+            {"name": "ATtiny1614/1604/814/804/414/404/214/204"},
+            {"name": "ATtiny412/402/212/202"},
+            {"name": "ATtiny3217/1617/1607/817/807/417"}
+          ],
+          "toolsDependencies": []
         }
       ],
       "tools": []


### PR DESCRIPTION
Boards Manager URL for testing: https://raw.githubusercontent.com/per1234/ReleaseScripts/add-101/package_drazzy.com_index.json