### PR TITLE
Define toolsDependencies for megaTinyCore

### DIFF
--- a/package_drazzy.com_index.json
+++ b/package_drazzy.com_index.json
@@ -520,7 +520,23 @@
             {"name": "ATtiny412/402/212/202"},
             {"name": "ATtiny3217/1617/1607/817/807"}
           ],
-          "toolsDependencies": []
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avr-gcc",
+              "version": "7.3.0-atmel3.6.1-arduino5"
+            },
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.3.0-arduino16"
+            },
+            {
+              "packager": "arduino",
+              "name": "arduinoOTA",
+              "version": "1.3.0"
+            }
+          ]
         },
         {
           "name": "megaTinyCore",
@@ -540,7 +556,23 @@
             {"name": "ATtiny412/402/212/202"},
             {"name": "ATtiny3217/1617/1607/817/807/417"}
           ],
-          "toolsDependencies": []
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avr-gcc",
+              "version": "7.3.0-atmel3.6.1-arduino5"
+            },
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.3.0-arduino16"
+            },
+            {
+              "packager": "arduino",
+              "name": "arduinoOTA",
+              "version": "1.3.0"
+            }
+          ]
         }
       ],
       "tools": []


### PR DESCRIPTION
This eliminates the need to install Arduino megaAVR Boards.

Temporary Boards Manager URL for testing:
https://raw.githubusercontent.com/per1234/ReleaseScripts/specify-tools/package_drazzy.com_index.json