### PR TITLE
Add Boards Manager installation support for ATTinyCore 1.2.5, megaTinyCore 1.0.2

### DIFF
--- a/package_drazzy.com_index.json
+++ b/package_drazzy.com_index.json
@@ -489,6 +489,42 @@
             {"name": "ATtiny43"}
           ],
           "toolsDependencies": []
+        },
+        {
+          "name": "ATTinyCore",
+          "architecture": "avr",
+          "version": "1.2.5",
+          "category": "Contributed",
+          "help": {
+            "online": ""
+          },
+          "url": "https://github.com/SpenceKonde/ATTinyCore/archive/1.2.5.tar.gz",
+          "archiveFileName": "ATTinyCore-1.2.5.tar.gz",
+          "checksum": "SHA-256:db0b7fca838436f04337d4faad47c109e10add1f8b716d689cec4858c8223afc",
+          "size": "5569027",
+          "boards": [
+            {"name": "ATtiny441"},
+            {"name": "ATtiny841"},
+            {"name": "ATtiny1634"},
+            {"name": "ATtiny828"},
+            {"name": "ATtiny2313"},
+            {"name": "ATtiny4313"},
+            {"name": "ATtiny24"},
+            {"name": "ATtiny44"},
+            {"name": "ATtiny84"},
+            {"name": "ATtiny25"},
+            {"name": "ATtiny45"},
+            {"name": "ATtiny85"},
+            {"name": "ATtiny261"},
+            {"name": "ATtiny461"},
+            {"name": "ATtiny861"},
+            {"name": "ATtiny87"},
+            {"name": "ATtiny167"},
+            {"name": "ATtiny48"},
+            {"name": "ATtiny88"},
+            {"name": "ATtiny43"}
+          ],
+          "toolsDependencies": []
         }
       ],
       "tools": []
@@ -550,6 +586,42 @@
           "archiveFileName": "megaTinyCore-1.0.1.tar.gz",
           "checksum": "SHA-256:a16cffad928e173ccb02f2af057a6449014b17a5b83e08133552f57e1e121a94",
           "size": "8088593",
+          "boards": [
+            {"name": "ATtiny3216/1616/1606/816/806/416/406"},
+            {"name": "ATtiny1614/1604/814/804/414/404/214/204"},
+            {"name": "ATtiny412/402/212/202"},
+            {"name": "ATtiny3217/1617/1607/817/807/417"}
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avr-gcc",
+              "version": "7.3.0-atmel3.6.1-arduino5"
+            },
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.3.0-arduino16"
+            },
+            {
+              "packager": "arduino",
+              "name": "arduinoOTA",
+              "version": "1.3.0"
+            }
+          ]
+        },
+        {
+          "name": "megaTinyCore",
+          "architecture": "megaavr",
+          "version": "1.0.2",
+          "category": "Contributed",
+          "help": {
+            "online": ""
+          },
+          "url": "https://github.com/SpenceKonde/megaTinyCore/archive/1.0.2.tar.gz",
+          "archiveFileName": "megaTinyCore-1.0.2.tar.gz",
+          "checksum": "SHA-256:1d6584523e00f780a488026cffc7b028127861bd316ad4ca0fdd92a2b5e13cad",
+          "size": "8123830",
           "boards": [
             {"name": "ATtiny3216/1616/1606/816/806/416/406"},
             {"name": "ATtiny1614/1604/814/804/414/404/214/204"},


### PR DESCRIPTION
Boards Manager URL for testing: https://raw.githubusercontent.com/per1234/ReleaseScripts/add-releases/package_drazzy.com_index.json
