### PR TITLE
Add Boards Manager installation support for megaTinyCore 1.0.3

### DIFF
--- a/package_drazzy.com_index.json
+++ b/package_drazzy.com_index.json
@@ -645,6 +645,42 @@
               "version": "1.3.0"
             }
           ]
+        },
+        {
+          "name": "megaTinyCore",
+          "architecture": "megaavr",
+          "version": "1.0.3",
+          "category": "Contributed",
+          "help": {
+            "online": ""
+          },
+          "url": "https://github.com/SpenceKonde/megaTinyCore/archive/1.0.3.tar.gz",
+          "archiveFileName": "megaTinyCore-1.0.3.tar.gz",
+          "checksum": "SHA-256:33bf921792d415b7798d58c98b045903ba94c1997b8e6da3581fb56cc34545c2",
+          "size": "7991244",
+          "boards": [
+            {"name": "ATtiny3216/1616/1606/816/806/416/406"},
+            {"name": "ATtiny1614/1604/814/804/414/404/214/204"},
+            {"name": "ATtiny412/402/212/202"},
+            {"name": "ATtiny3217/1617/1607/817/807/417"}
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avr-gcc",
+              "version": "7.3.0-atmel3.6.1-arduino5"
+            },
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.3.0-arduino16"
+            },
+            {
+              "packager": "arduino",
+              "name": "arduinoOTA",
+              "version": "1.3.0"
+            }
+          ]
         }
       ],
       "tools": []


### PR DESCRIPTION
Boards Manager URL for testing:
https://raw.githubusercontent.com/per1234/ReleaseScripts/add-103/package_drazzy.com_index.json
