### PR TITLE
Specify avrdude 6.3.0-arduino17 tool dependency for ATtinyCore

### DIFF
--- a/package_drazzy.com_index.json
+++ b/package_drazzy.com_index.json
@@ -38,7 +38,13 @@
             {"name": "ATtiny48"},
             {"name": "ATtiny88"}
           ],
-          "toolsDependencies": []
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.3.0-arduino17"
+            }
+          ]
         },
         {
           "name": "ATTinyCore",
@@ -69,7 +75,13 @@
             {"name": "ATtiny48"},
             {"name": "ATtiny88"}
           ],
-          "toolsDependencies": []
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.3.0-arduino17"
+            }
+          ]
         },
         {
           "name": "ATTinyCore",
@@ -100,7 +112,13 @@
             {"name": "ATtiny48"},
             {"name": "ATtiny88"}
           ],
-          "toolsDependencies": []
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.3.0-arduino17"
+            }
+          ]
         },
         {
           "name": "ATTinyCore",
@@ -135,7 +153,13 @@
             {"name": "ATtiny48"},
             {"name": "ATtiny88"}
           ],
-          "toolsDependencies": []
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.3.0-arduino17"
+            }
+          ]
         },
         {
           "name": "ATTinyCore",
@@ -170,7 +194,13 @@
             {"name": "ATtiny48"},
             {"name": "ATtiny88"}
           ],
-          "toolsDependencies": []
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.3.0-arduino17"
+            }
+          ]
         },
         {
           "name": "ATTinyCore",
@@ -205,7 +235,13 @@
             {"name": "ATtiny48"},
             {"name": "ATtiny88"}
           ],
-          "toolsDependencies": []
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.3.0-arduino17"
+            }
+          ]
         },
         {
           "name": "ATTinyCore",
@@ -240,7 +276,13 @@
             {"name": "ATtiny48"},
             {"name": "ATtiny88"}
           ],
-          "toolsDependencies": []
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.3.0-arduino17"
+            }
+          ]
         },
         {
           "name": "ATTinyCore",
@@ -275,7 +317,13 @@
             {"name": "ATtiny48"},
             {"name": "ATtiny88"}
           ],
-          "toolsDependencies": []
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.3.0-arduino17"
+            }
+          ]
         },
         {
           "name": "ATTinyCore",
@@ -310,7 +358,13 @@
             {"name": "ATtiny48"},
             {"name": "ATtiny88"}
           ],
-          "toolsDependencies": []
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.3.0-arduino17"
+            }
+          ]
         },
         {
           "name": "ATTinyCore",
@@ -345,7 +399,13 @@
             {"name": "ATtiny48"},
             {"name": "ATtiny88"}
           ],
-          "toolsDependencies": []
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.3.0-arduino17"
+            }
+          ]
         },
         {
           "name": "ATTinyCore",
@@ -380,7 +440,13 @@
             {"name": "ATtiny48"},
             {"name": "ATtiny88"}
           ],
-          "toolsDependencies": []
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.3.0-arduino17"
+            }
+          ]
         },
         {
           "name": "ATTinyCore",
@@ -416,7 +482,13 @@
             {"name": "ATtiny88"},
             {"name": "ATtiny43"}
           ],
-          "toolsDependencies": []
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.3.0-arduino17"
+            }
+          ]
         },
         {
           "name": "ATTinyCore",
@@ -452,7 +524,13 @@
             {"name": "ATtiny88"},
             {"name": "ATtiny43"}
           ],
-          "toolsDependencies": []
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.3.0-arduino17"
+            }
+          ]
         },
         {
           "name": "ATTinyCore",
@@ -488,7 +566,13 @@
             {"name": "ATtiny88"},
             {"name": "ATtiny43"}
           ],
-          "toolsDependencies": []
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.3.0-arduino17"
+            }
+          ]
         },
         {
           "name": "ATTinyCore",
@@ -524,7 +608,13 @@
             {"name": "ATtiny88"},
             {"name": "ATtiny43"}
           ],
-          "toolsDependencies": []
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.3.0-arduino17"
+            }
+          ]
         }
       ],
       "tools": []


### PR DESCRIPTION
avrdude 6.3.0-arduino16 used by the current version of Arduino megaAVR Boards has a bug that affects the USBtinyISP programmer. Prior to this change, ATTinyCore would use the newest installed version of avrdude, so installing Arduino megaAVR Boards would break USBtinyISP for ATTinyCore. This bug in avrdude has been fixed in avrdude 6.3.0-arduino17. By specifying avrdude 6.3.0-arduino17 as a dependency, that version of avrdude will be installed during the Boards Manager installation and used when uploading to ATtinyCore. This does not fix the problem for existing Boards Manager installations and manual installations.