### PR TITLE
Add Boards Manager installation support for ATTinyCore 1.3.1, megaTinyCore 1.0.5

### DIFF
--- a/package_drazzy.com_index.json
+++ b/package_drazzy.com_index.json
@@ -572,6 +572,53 @@
               "version": "6.3.0-arduino17"
             }
           ]
+        },
+        {
+          "name": "ATTinyCore",
+          "architecture": "avr",
+          "version": "1.3.1",
+          "category": "Contributed",
+          "help": {
+            "online": ""
+          },
+          "url": "https://github.com/SpenceKonde/ATTinyCore/archive/1.3.1.tar.gz",
+          "archiveFileName": "ATTinyCore-1.3.1.tar.gz",
+          "checksum": "SHA-256:33a5530b4d901b2a9712aa30aee8c7083fb461eb86911a019ce237b482107027",
+          "size": "5464866",
+          "boards": [
+            {"name": "ATtiny441"},
+            {"name": "ATtiny841"},
+            {"name": "ATtiny1634"},
+            {"name": "ATtiny828"},
+            {"name": "ATtiny2313"},
+            {"name": "ATtiny4313"},
+            {"name": "ATtiny24"},
+            {"name": "ATtiny44"},
+            {"name": "ATtiny84"},
+            {"name": "ATtiny25"},
+            {"name": "ATtiny45"},
+            {"name": "ATtiny85"},
+            {"name": "ATtiny261"},
+            {"name": "ATtiny461"},
+            {"name": "ATtiny861"},
+            {"name": "ATtiny87"},
+            {"name": "ATtiny167"},
+            {"name": "ATtiny48"},
+            {"name": "ATtiny88"},
+            {"name": "ATtiny43"}
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avr-gcc",
+              "version": "7.3.0-atmel3.6.1-arduino5"
+            },
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.3.0-arduino17"
+            }
+          ]
         }
       ],
       "tools": []
@@ -741,6 +788,42 @@
           "archiveFileName": "megaTinyCore-1.0.4.tar.gz",
           "checksum": "SHA-256:d7b46210fdab1cc62e39e7838086af5fdc337b5a68fdd69d3e9282a370bf3b98",
           "size": "7992688",
+          "boards": [
+            {"name": "ATtiny3216/1616/1606/816/806/416/406"},
+            {"name": "ATtiny1614/1604/814/804/414/404/214/204"},
+            {"name": "ATtiny412/402/212/202"},
+            {"name": "ATtiny3217/1617/1607/817/807/417"}
+          ],
+          "toolsDependencies": [
+            {
+              "packager": "arduino",
+              "name": "avr-gcc",
+              "version": "7.3.0-atmel3.6.1-arduino5"
+            },
+            {
+              "packager": "arduino",
+              "name": "avrdude",
+              "version": "6.3.0-arduino17"
+            },
+            {
+              "packager": "arduino",
+              "name": "arduinoOTA",
+              "version": "1.3.0"
+            }
+          ]
+        },
+        {
+          "name": "megaTinyCore",
+          "architecture": "megaavr",
+          "version": "1.0.5",
+          "category": "Contributed",
+          "help": {
+            "online": ""
+          },
+          "url": "https://github.com/SpenceKonde/megaTinyCore/archive/1.0.5.tar.gz",
+          "archiveFileName": "megaTinyCore-1.0.5.tar.gz",
+          "checksum": "SHA-256:9f9597271562d8c36d2baae40b7a5613fdb8adc9d5a696b95daed76166363081",
+          "size": "7997359",
           "boards": [
             {"name": "ATtiny3216/1616/1606/816/806/416/406"},
             {"name": "ATtiny1614/1604/814/804/414/404/214/204"},


### PR DESCRIPTION
Boards Manager URL for testing: https://raw.githubusercontent.com/per1234/ReleaseScripts/add-131/package_drazzy.com_index.json
