### PR TITLE
Add missing packages[].tools object for DxCore to package index

### DIFF
--- a/package_drazzy.com_index.json
+++ b/package_drazzy.com_index.json
@@ -848,7 +848,8 @@
             }
           ]
         }
-      ]
+      ],
+      "tools": []
     },
     {
       "name": "megaTinyCore",


### PR DESCRIPTION
Omitting this object from a package definition causes Arduino IDE versions prior to 1.8.12 to no longer start once the malformed package index has been downloaded.

Reference: https://github.com/arduino/Arduino/issues/10335#issuecomment-641840027

Fixes https://github.com/SpenceKonde/ATTinyCore/issues/446

Boards Manager URL for testing: https://raw.githubusercontent.com/per1234/ReleaseScripts/fix-index/package_drazzy.com_index.json