### PR TITLE
Correct archive URL for DxCore 1.0.0

### DIFF
--- a/package_drazzy.com_index.json
+++ b/package_drazzy.com_index.json
@@ -821,7 +821,7 @@
           "help": {
             "online": ""
           },
-          "url": "https://github.com/SpenceKonde/megaTinyCore/archive/1.0.0.tar.gz",
+          "url": "https://github.com/SpenceKonde/DxCore/archive/1.0.0.tar.gz",
           "archiveFileName": "DxCore-1.0.0.tar.gz",
           "checksum": "SHA-256:001a04f0ed405d6cdcab7680bfd09b73e24370559bc6cb6cbd3a8f9100508a28",
           "size": "28388381",


### PR DESCRIPTION
It was previously pointing at the megaTinyCore 1.0.0 archive.

Boards Manager URL for testing: https://raw.githubusercontent.com/per1234/ReleaseScripts/fix-url/package_drazzy.com_index.json