### PR TITLE
Fix errors in package index entry for DxCore 1.0.1

### DIFF
--- a/package_drazzy.com_index.json
+++ b/package_drazzy.com_index.json
@@ -908,9 +908,9 @@
           "help": {
             "online": ""
           },
-          "url": "https://github.com/SpenceKonde/DxCore/archive/1.0.1.tar.gz",
+          "url": "https://github.com/SpenceKonde/DxCore/archive/1.0.1_.tar.gz",
           "archiveFileName": "DxCore-1.0.1_.tar.gz",
-          "checksum": "SHA-256:7f3392c073c45ab98587261ef752f127a62cfabfe122e99ff5f371ac920a695d",
+          "checksum": "SHA-256:8a8d32db3cc0c568d6e5e4eec14f65505e5772f9bad7d4231ec45722073aa84e",
           "size": "11469196",
           "boards": [
             {"name": "AVR128DA28,AVR128DA32,AVR128DA48,AVR128DA64"},

--- a/package_drazzy.com_index.json
+++ b/package_drazzy.com_index.json
@@ -920,7 +920,7 @@
           ],
           "toolsDependencies": [
             {
-              "packager": "ATTinyCore",
+              "packager": "DxCore",
               "name": "avr-gcc",
               "version": "7.3.0-atmel3.6.1-azzy1"
             },


### PR DESCRIPTION
### Correct packager name in toolsDependencies reference

The avr-gcc 7.3.0-atmel3.6.1-azzy1 tool is defined under the `DxCore` packager/vendor (as defined by the `packages[].name` field)'s package, so the `packager` field must be `DxCore`.

Reference:
https://arduino.github.io/arduino-cli/dev/package_index_json-specification/#tools-definitions

### Use correct platform archive URL

The previous platform archive URL was for a release asset that had the manual installation structure.

Fixes SpenceKonde/DxCore#6

---
Boards Manager URL for testing: https://raw.githubusercontent.com/per1234/ReleaseScripts/fix-index/package_drazzy.com_index.json

---
Unfortunately, there is still another issue with the release that I can't fix:

```
Arduino: 1.8.13 (Linux), Board: "AVR Dx 28, AVR128DB28, 24 MHz, Enabled, 1.9V, Disabled, Disabled, EEPROM retained, Hardware Reset (recommended), TCB1 (will break tone)"

fork/exec /home/per/.arduino15/packages/DxCore/tools/avr-gcc/7.3.0-atmel3.6.1-azzy1/bin/avr-g++: permission denied
Error compiling for board AVR Dx 28.
```
The problem is avr-gcc binaries are not set to executable. This is likely a problem on Linux and macOS, but not an issue on Windows.