### PR TITLE
Use semver-compliant version number for DxCore 1.1.0a

### DIFF
--- a/package_drazzy.com_index.json
+++ b/package_drazzy.com_index.json
@@ -903,7 +903,7 @@
         {
           "name": "DxCore",
           "architecture": "megaavr",
-          "version": "1.1.0a",
+          "version": "1.1.0-a",
           "category": "Contributed",
           "help": {
             "online": ""
@@ -953,7 +953,7 @@
           "boards": [
             {"name": "AVR128DA28,AVR128DA32,AVR128DA48,AVR128DA64"},
             {"name": "DB-series and 32/64k DA-series not supported by Arduino toolchain"},
-            {"name": "Non-linux platforms can install 1.1.0a instead to support those parts"}
+            {"name": "Non-linux platforms can install 1.1.0-a instead to support those parts"}
           ],
           "toolsDependencies": [
             {


### PR DESCRIPTION
Use of a non-[semver](https://semver.org/) compliant version number causes:

- DxCore 1.1.0a to not be available in the Arduino IDE Boards Manager
- Arduino CLI to no longer work once the http://drazzy.com/package_drazzy.com_index.json Boards Manager URL is added to the configuration
- Arduino Pro IDE to show error messages on startup (https://github.com/arduino/arduino-pro-ide/issues/308) and not shown any of the platforms from  http://drazzy.com/package_drazzy.com_index.json in Boards Manager (https://github.com/SpenceKonde/ReleaseScripts/issues/33)

Boards Manager URL for testing: https://raw.githubusercontent.com/per1234/ReleaseScripts/use-semver-platform-version/package_drazzy.com_index.json

Fixes https://github.com/SpenceKonde/ReleaseScripts/issues/33