### PR TITLE
Correct tool reference in `megaTinyCore:megaavr@2.5.8`

### DIFF
--- a/package_drazzy.com_index.json
+++ b/package_drazzy.com_index.json
@@ -5465,7 +5465,7 @@
               "version": "7.3.0-atmel3.6.1-azduino4b"
             },
             {
-              "packager": "arduino",
+              "packager": "DxCore",
               "name": "avrdude",
               "version": "6.3.0-arduino17or18"
             },


### PR DESCRIPTION
The `avrdude` [tool dependency](https://arduino.github.io/arduino-cli/latest/package_index_json-specification/#:~:text=toolsDependencies%3A%20the%20tools%20needed%20by%20this%20platform) for this release was accidentally referenced as `arduino:avrdude@6.3.0-arduino17or18`, which does not exist (https://github.com/SpenceKonde/megaTinyCore/discussions/623).

That error was resolved in [the `megaTinyCore:megaavr@2.5.9` release](https://github.com/SpenceKonde/ReleaseScripts/commit/209c8bb271640e49484c67dfda8c31da70ba83fe). However, the incorrect tool reference remains in the `megaTinyCore:megaavr@2.5.8` entry of the index, which causes Arduino IDE 1.x users with `http://drazzy.com/package_drazzy.com_index.json` in their "**Additional Boards Manager URLs**" preference (regardless of whether they have megaTinyCore installed or not) to be shown the following error each time Boards Manager or Library Manager is used:

```
Index error: could not find referenced tool name=avrdude version=6.3.0-arduino17or18 packager=arduino
```

Even though it doesn't appear to do any real harm, this error message can cause consternation for the users ([example](https://groups.google.com/a/arduino.cc/g/developers/c/Gvizt5JQ2AQ)), act as a "red herring", or just be annoying. So I think it is worth correcting.

---

Temporary Boards Manager URL for testing:
https://raw.githubusercontent.com/per1234/ReleaseScripts/fix-tool-reference/package_drazzy.com_index.json