### PR TITLE
Correct URL for `DxCore:avr-gcc@7.3.0-atmel3.6.1-azduino8a` archive

### DIFF
--- a/package_drazzy.com_index.json
+++ b/package_drazzy.com_index.json
@@ -4001,7 +4001,7 @@
               "checksum": "SHA-256:ffce8ce1ef79bd6ec25a1a7154900966bcfdcd1731eb5d1e45c60e914a655e1d",
               "host": "x86_64-pc-linux-gnu",
               "archiveFileName": "avr-gcc-7.3.0-atmel3.6.1-azduino8-x86_64-pc-linux-gnu.tar.bz2",
-              "url": "https://github.com/SpenceKonde/DxCore/blob/gh-pages/avr-gcc-7.3.0-atmel3.6.1-azduino8-x86_64-pc-linux-gnu.tar.bz2"
+              "url": "https://spencekondetoolchains.s3.us-east-1.amazonaws.com/avr-gcc-7.3.0-atmel3.6.1-azduino8-x86_64-pc-linux-gnu.tar.bz2"
             },
             {
               "size": "44053393",


### PR DESCRIPTION
The previous URL was that of the page for the file on the GitHub repository website, not the URL of the file download. This caused Boards Manager to the HTML file of the web page instead of the archive file. That resulted in the platform installation failing due to the file not passing checksum verification:

```text
megaTinyCore:megaavr@2.6.12
Installing DxCore:avr-gcc@7.3.0-atmel3.6.1-azduino8a
Failed to install platform: 'megaTinyCore:megaavr:2.6.12'.
Error: 13 INTERNAL: Cannot install tool DxCore:avr-gcc@7.3.0-atmel3.6.1-azduino8a: testing local archive integrity: testing archive checksum: archive hash differs from hash in index
```

---

Fixes https://github.com/SpenceKonde/megaTinyCore/issues/1247